### PR TITLE
Comillas delimitando cadena de texto

### DIFF
--- a/puntos/10.tex
+++ b/puntos/10.tex
@@ -48,7 +48,7 @@
     {Acceso a atributos de argumentos por nombre}
     \scriptsize
     \begin{lstlisting}
->>> kwargs = {numero : 1+5j}
+>>> kwargs = {'numero' : 1+5j}
 >>> "Parte imaginaria: {numero.imag}".format(**kwargs)
 'Parte imaginaria: 5.0'
     \end{lstlisting}


### PR DESCRIPTION
Faltan unas comillas, a menos que numero sea una variable que contenga la cadena "numero" xD
