### PR TITLE
Un "que" menos

### DIFF
--- a/puntos/28.tex
+++ b/puntos/28.tex
@@ -58,7 +58,7 @@
     debería ser aquella que, pasada a \structure{eval()}, devuelve el
     mismo objeto. Al fin y al cabo, si \structure{eval()} es capaz de
     reconstruir el objeto a partir de ella, esto garantiza que
-    contiene \structure{toda} la infomación que necesaria:
+    contiene \structure{toda} la infomación necesaria:
   \end{block}
 
   \footnotesize


### PR DESCRIPTION
Otra opción sería poner "que es" en lugar de "que".
