### PR TITLE
Caracteres especiales de Latex

### DIFF
--- a/puntos/30.tex
+++ b/puntos/30.tex
@@ -76,12 +76,12 @@ SyntaxError: keyword can't be an expression
   \begin{center}
     \centering
     Doug Hellmann, por ejemplo, ha cuantificado que es seis veces más
-    lento que {}, y que consume más memoria.
+    lento que \{\}, y que consume más memoria.
   \end{center}
 
   \footnotesize
     \begin{block}
-    {\centering The Performance Impact of Using dict() Instead of {} in CPython 2.7}
+    {\centering The Performance Impact of Using dict() Instead of \{\} in CPython 2.7}
     \centering
     \url{http://doughellmann.com/2012/11/the-performance-impact-of-using-dict-instead-of-in-cpython-2-7-2.html}
   \end{block}


### PR DESCRIPTION
Sustitución de "{}" por "\{\}" en dos casos que era necesario.
